### PR TITLE
Add TNS firewall option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ usage:
                     [--get-dpk]
                     [--setup-dpk]
                     [--firewall-pia]
+                    [--firewall-db]
                     [--dpk-source=<type> --dpk-platform=<type> --dpk-type=<type>]
                     [--dpk-version=<nbr> --dpk-patch=<nbr>]
     ioco dpk undeploy [options]

--- a/examples/config.json.example
+++ b/examples/config.json.example
@@ -51,6 +51,7 @@
     "opr_pwd": "PS",
     "patch_id": null,
     "pia_port": "8000",
+    "db_port": "1521",
     "ps_cfg_dir": "/u01/app/oracle/product/hostname/ps_cfg_home",
     "psft_base_dir": "/u01/app/oracle/product",
     "read": null,

--- a/ioco/__main__.py
+++ b/ioco/__main__.py
@@ -7,6 +7,7 @@ usage:
                     [--get-dpk]
                     [--setup-dpk]
                     [--firewall-pia]
+                    [--firewall-db]
                     [--dpk-source=<type> --dpk-platform=<type> --dpk-type=<type>]
                     [--dpk-version=<nbr> --dpk-patch=<nbr>]
     ioco dpk undeploy [options]

--- a/ioco/dpk.py
+++ b/ioco/dpk.py
@@ -73,7 +73,8 @@ def init(config):
         and not this.config['--install-packages'] \
         and not this.config['--get-dpk'] \
         and not this.config['--setup-dpk'] \
-        and not this.config['--firewall-pia']
+        and not this.config['--firewall-pia'] \
+        and not this.config['--firewall-db']
 
     # Setting credential variables
     this.config['mos_username']  = os.getenv("MOS_USERNAME")
@@ -97,6 +98,8 @@ def deploy():
         __setup_dpk()
     if this.config.get('--all-dpk') or this.config.get('--firewall-pia'):
         __firewall_pia()
+    if this.config.get('--all-dpk') or this.config.get('--firewall-db'):
+        __firewall_db()
 
     __done()
 
@@ -422,7 +425,7 @@ def __get_dpk_status():
                 json.dump(dpk_status, f)
         except FileNotFoundError:
             logging.error("DPK files directory not created. Try again with '--setup-file-system'")
-            util.error_timings(timing_key)
+            # util.error_timings(timing_key)
             exit(2)
         except:
             logging.error("Issue creating DPK status file")
@@ -554,6 +557,13 @@ def __firewall_pia():
         subprocess.run(["sudo","firewall-cmd", "--zone=public", "--add-port=" + str(this.config.get('pia_port')) + "/tcp"], check=True)
     except:
         logging.error("Firewall PIA port failed.")
+        raise
+def __firewall_db():
+    logging.info("Updating firewall for TNS")
+    try:
+        subprocess.run(["sudo","firewall-cmd", "--zone=public", "--add-port=" + str(this.config.get('db_port')) + "/tcp"], check=True)
+    except:
+        logging.error("Firewall TNS port failed.")
         raise
 
 def __done():

--- a/ioco/dpk.py
+++ b/ioco/dpk.py
@@ -92,14 +92,14 @@ def deploy():
         __setup_file_system()
     if this.config.get('--all-dpk') or this.config.get('--install-packages'):
         __install_packages()
-    if this.config.get('--all-dpk') or this.config.get('--get-dpk'):
-        __get_dpk()
-    if this.config.get('--all-dpk') or this.config.get('--setup-dpk'):
-        __setup_dpk()
     if this.config.get('--all-dpk') or this.config.get('--firewall-pia'):
         __firewall_pia()
     if this.config.get('--all-dpk') or this.config.get('--firewall-db'):
         __firewall_db()
+    if this.config.get('--all-dpk') or this.config.get('--get-dpk'):
+        __get_dpk()
+    if this.config.get('--all-dpk') or this.config.get('--setup-dpk'):
+        __setup_dpk()
 
     __done()
 

--- a/ioco/util.py
+++ b/ioco/util.py
@@ -76,6 +76,7 @@ def get_config(args):
         'db_name': 'PSFTDB',
         'db_host': 'localhost',
         'pia_port': '8000',
+        'db_port': '1521',
         'opr_id': 'PS',
         'opr_pwd': 'PS',
         'gw_user_pwd': 'password',


### PR DESCRIPTION
Add a new option `--firewall-db` to add a TNS port to the firewall. Port defaults to `1521`, but can be configured in `config.json`:

```json
{
  "db_port": "1521"
}
```

Also moved the `firewall-*` functions to execute before running DPK setup. In some tests, the VCN DNS name was used for the TNS entry and failed when the firewall was not open for TNS.